### PR TITLE
Fix object property serialization, error resilience, and batch tool

### DIFF
--- a/tests/integration/query-tools-mcp.test.ts
+++ b/tests/integration/query-tools-mcp.test.ts
@@ -152,9 +152,10 @@ describe('Query Tools MCP Integration', () => {
         t.name === 'iac_mcp_query_object' ||
         t.name === 'iac_mcp_get_properties' ||
         t.name === 'iac_mcp_set_property' ||
-        t.name === 'iac_mcp_get_elements'
+        t.name === 'iac_mcp_get_elements' ||
+        t.name === 'iac_mcp_get_elements_with_properties'
       );
-      expect(queryTools).toHaveLength(4);
+      expect(queryTools).toHaveLength(5);
 
       // Should also have list_apps tool
       const listAppsTool = tools.find(t => t.name === 'list_apps');

--- a/tests/unit/jitd/tool-generator/query-tools.test.ts
+++ b/tests/unit/jitd/tool-generator/query-tools.test.ts
@@ -3,11 +3,11 @@ import { generateQueryTools } from "../../../../src/jitd/tool-generator/query-to
 import { Tool } from "@modelcontextprotocol/sdk/types.js";
 
 describe("generateQueryTools", () => {
-  describe("Function Returns 4 Tools", () => {
-    it("should return an array of 4 tools", () => {
+  describe("Function Returns 5 Tools", () => {
+    it("should return an array of 5 tools", () => {
       const tools = generateQueryTools();
       expect(tools).toBeInstanceOf(Array);
-      expect(tools).toHaveLength(4);
+      expect(tools).toHaveLength(5);
     });
 
     it("should return tools with name, description, and inputSchema", () => {
@@ -240,6 +240,63 @@ describe("generateQueryTools", () => {
 
     it("should mention elements can be used in further operations", () => {
       expect(getElementsTool.description).toContain("further operations");
+    });
+  });
+
+  describe("Tool 5: get_elements_with_properties", () => {
+    let batchTool: Tool;
+
+    beforeEach(() => {
+      const tools = generateQueryTools();
+      batchTool = tools.find((t) => t.name === "iac_mcp_get_elements_with_properties")!;
+    });
+
+    it("should have correct name", () => {
+      expect(batchTool.name).toBe("iac_mcp_get_elements_with_properties");
+    });
+
+    it("should have description mentioning batch operation", () => {
+      expect(batchTool.description.toLowerCase()).toContain("batch");
+    });
+
+    it("should have inputSchema with container, elementType, properties, app, and limit", () => {
+      const schema = batchTool.inputSchema as any;
+      expect(schema.type).toBe("object");
+      expect(schema.properties).toHaveProperty("container");
+      expect(schema.properties).toHaveProperty("elementType");
+      expect(schema.properties).toHaveProperty("properties");
+      expect(schema.properties).toHaveProperty("app");
+      expect(schema.properties).toHaveProperty("limit");
+    });
+
+    it("should require container, elementType, and properties", () => {
+      const schema = batchTool.inputSchema as any;
+      expect(schema.required).toEqual(
+        expect.arrayContaining(["container", "elementType", "properties"])
+      );
+      expect(schema.required).toHaveLength(3);
+    });
+
+    it("should define container using oneOf (string or object)", () => {
+      const schema = batchTool.inputSchema as any;
+      expect(schema.properties.container.oneOf).toBeDefined();
+      expect(schema.properties.container.oneOf).toHaveLength(2);
+
+      const types = schema.properties.container.oneOf.map((s: any) => s.type);
+      expect(types).toContain("string");
+      expect(types).toContain("object");
+    });
+
+    it("should define properties as array of strings", () => {
+      const schema = batchTool.inputSchema as any;
+      expect(schema.properties.properties.type).toBe("array");
+      expect(schema.properties.properties.items.type).toBe("string");
+    });
+
+    it("should define limit with default value of 100", () => {
+      const schema = batchTool.inputSchema as any;
+      expect(schema.properties.limit.type).toBe("number");
+      expect(schema.properties.limit.default).toBe(100);
     });
   });
 


### PR DESCRIPTION
## Summary
- **Object reference serialization**: Single object properties (e.g., `mailbox`, `currentTab`) that were silently dropped from results now return stored reference IDs via new `object_reference` markers
- **Per-property error resilience**: Each property access is wrapped in try-catch so one failing property (e.g., Safari's `url` on blank tab) doesn't kill the entire response — returns `_error` marker instead
- **Batch tool**: New `get_elements_with_properties` tool reduces round trips from 2N+1 to 1-2 JXA calls by fetching elements AND their properties in a single operation

## Files Changed

| File | Changes |
|------|---------|
| `src/execution/query-executor.ts` | Object detection in JXA templates, post-processing, `createPropertyReference()`, `getElementsWithProperties()` |
| `src/jitd/tool-generator/query-tools.ts` | New `iac_mcp_get_elements_with_properties` tool definition |
| `src/mcp/handlers.ts` | Type guard, dispatch block, handler for batch tool |
| `tests/unit/execution/query-executor.test.ts` | 24 new tests (object refs, error resilience, batch) |
| `tests/integration/reference-lifecycle.test.ts` | 5 new integration tests |
| `tests/unit/jitd/tool-generator/query-tools.test.ts` | Updated count + 7 new tests for 5th tool |
| `tests/integration/query-tools-mcp.test.ts` | Updated query tool count |

## Test plan
- [x] All 2718 tests pass (1 pre-existing failure in real-sdef-validation unrelated to this PR)
- [x] Unit tests cover object_reference detection, _error markers, createPropertyReference, getElementsWithProperties
- [x] Integration tests cover reference lifecycle for new property references
- [ ] Manual test with Claude Desktop: Mail selectedMessages, mailbox refs, Safari url error resilience

🤖 Generated with [Claude Code](https://claude.com/claude-code)