### PR TITLE
Add large value handling for MCP property responses

### DIFF
--- a/src/execution/large-value-cache.ts
+++ b/src/execution/large-value-cache.ts
@@ -1,0 +1,146 @@
+import { randomUUID } from 'crypto';
+
+/**
+ * Cached large value entry.
+ * Stores the full string value along with metadata for paging.
+ */
+export interface CachedValue {
+  value: string;
+  propertyName: string;
+  sourceRef: string;
+  totalLines: number;
+  totalChars: number;
+  cachedAt: number;
+  lastAccessedAt: number;
+}
+
+/** Threshold above which string values are auto-cached (50KB) */
+export const LARGE_VALUE_THRESHOLD = 50 * 1024;
+
+/** Default maximum number of cached values */
+export const DEFAULT_MAX_CACHED_VALUES = 100;
+
+/** Default time-to-live for cached values (15 minutes) */
+export const DEFAULT_TTL_MS = 15 * 60 * 1000;
+
+/** Number of preview lines included in the large value marker */
+export const PREVIEW_LINES = 50;
+
+/**
+ * Cache for large property values that exceed the transport threshold.
+ *
+ * When a property value exceeds LARGE_VALUE_THRESHOLD, it is stored here
+ * and the response contains a preview + cache reference for paging.
+ *
+ * Uses LRU eviction when maxEntries is exceeded and TTL-based expiry on get().
+ */
+export class LargeValueCache {
+  private entries: Map<string, CachedValue> = new Map();
+  private maxEntries: number;
+  private ttlMs: number;
+
+  constructor(options?: { maxEntries?: number; ttlMs?: number }) {
+    this.maxEntries = options?.maxEntries ?? DEFAULT_MAX_CACHED_VALUES;
+    this.ttlMs = options?.ttlMs ?? DEFAULT_TTL_MS;
+  }
+
+  /**
+   * Store a large value in the cache.
+   *
+   * @param value - The full string value to cache
+   * @param propertyName - The property name that produced this value
+   * @param sourceRef - The reference ID of the object that owns the property
+   * @returns Cache ID (format: cache_<uuid>)
+   */
+  store(value: string, propertyName: string, sourceRef: string): string {
+    // Evict if at capacity
+    if (this.entries.size >= this.maxEntries) {
+      this.evictLRU();
+    }
+
+    const id = `cache_${randomUUID()}`;
+    const now = Date.now();
+    this.entries.set(id, {
+      value,
+      propertyName,
+      sourceRef,
+      totalLines: value.split('\n').length,
+      totalChars: value.length,
+      cachedAt: now,
+      lastAccessedAt: now,
+    });
+
+    return id;
+  }
+
+  /**
+   * Retrieve a cached value by ID.
+   * Updates lastAccessedAt on access. Returns undefined if expired or not found.
+   *
+   * @param id - Cache ID (format: cache_<uuid>)
+   * @returns The cached value or undefined
+   */
+  get(id: string): CachedValue | undefined {
+    const entry = this.entries.get(id);
+    if (!entry) return undefined;
+
+    // Check TTL
+    if (Date.now() - entry.cachedAt > this.ttlMs) {
+      this.entries.delete(id);
+      return undefined;
+    }
+
+    // Touch for LRU
+    entry.lastAccessedAt = Date.now();
+    return entry;
+  }
+
+  /**
+   * Delete a cached value by ID.
+   *
+   * @param id - Cache ID to delete
+   * @returns true if the entry existed and was deleted
+   */
+  delete(id: string): boolean {
+    return this.entries.delete(id);
+  }
+
+  /**
+   * Clear all cached values.
+   */
+  clear(): void {
+    this.entries.clear();
+  }
+
+  /**
+   * Get cache statistics.
+   *
+   * @returns Total entries and total bytes stored
+   */
+  getStats(): { totalEntries: number; totalBytes: number } {
+    let totalBytes = 0;
+    for (const entry of this.entries.values()) {
+      totalBytes += entry.totalChars;
+    }
+    return { totalEntries: this.entries.size, totalBytes };
+  }
+
+  /**
+   * Evict the least recently used entry.
+   */
+  private evictLRU(): void {
+    let oldestKey: string | undefined;
+    let oldestTime = Infinity;
+
+    for (const [key, entry] of this.entries) {
+      if (entry.lastAccessedAt < oldestTime) {
+        oldestTime = entry.lastAccessedAt;
+        oldestKey = key;
+      }
+    }
+
+    if (oldestKey) {
+      this.entries.delete(oldestKey);
+    }
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ import { ReferenceStore } from './execution/reference-store.js';
 import { QueryExecutor } from './execution/query-executor.js';
 import { JXAExecutor } from './adapters/macos/jxa-executor.js';
 import { SystemEventsExecutor } from './execution/system-events-executor.js';
+import { LargeValueCache } from './execution/large-value-cache.js';
 
 /**
  * Logging utility that writes to stderr (stdout is reserved for MCP protocol)
@@ -64,7 +65,8 @@ async function main(): Promise<void> {
   // Initialize query execution components
   const referenceStore = new ReferenceStore(15 * 60 * 1000); // 15-minute TTL
   const jxaExecutor = new JXAExecutor();
-  const queryExecutor = new QueryExecutor(referenceStore, jxaExecutor);
+  const largeValueCache = new LargeValueCache();
+  const queryExecutor = new QueryExecutor(referenceStore, jxaExecutor, largeValueCache);
   const systemEventsExecutor = new SystemEventsExecutor(referenceStore, jxaExecutor);
 
   // Setup all MCP handlers

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -28,6 +28,7 @@ import { PerAppCache } from '../jitd/cache/per-app-cache.js';
 import { ReferenceStore } from '../execution/reference-store.js';
 import { QueryExecutor } from '../execution/query-executor.js';
 import { SystemEventsExecutor } from '../execution/system-events-executor.js';
+import { LargeValueCache } from '../execution/large-value-cache.js';
 import { setupHandlers } from './handlers.js';
 
 /**
@@ -179,9 +180,10 @@ export class IACMCPServer {
     // Initialize query execution components
     // Pass JXAExecutor only if JXA execution is enabled (default: enabled)
     this.referenceStore = new ReferenceStore(15 * 60 * 1000); // 15-minute TTL
+    const largeValueCache = new LargeValueCache();
     this.queryExecutor = this.options.disableJxaExecution
-      ? new QueryExecutor(this.referenceStore)
-      : new QueryExecutor(this.referenceStore, this.jxaExecutor);
+      ? new QueryExecutor(this.referenceStore, undefined, largeValueCache)
+      : new QueryExecutor(this.referenceStore, this.jxaExecutor, largeValueCache);
 
     // Initialize System Events executor (shares ReferenceStore with query executor)
     this.systemEventsExecutor = this.options.disableJxaExecution

--- a/tests/integration/large-value-mcp.test.ts
+++ b/tests/integration/large-value-mcp.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Integration Tests for Large Value Handling in MCP
+ *
+ * Tests the MCP server integration for:
+ * - get_cached_value tool appears in ListTools
+ * - tail_lines/head_lines params in property tool schemas
+ * - CallTool routes correctly for get_cached_value
+ * - Mutual exclusivity validation for tail_lines/head_lines
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { IACMCPServer } from '../../src/mcp/server.js';
+import type { MCPTool } from '../../src/types/mcp-tool.js';
+
+describe('Large Value Handling MCP Integration', () => {
+  let server: IACMCPServer;
+
+  beforeEach(async () => {
+    server = new IACMCPServer({ enableLogging: false, disableJxaExecution: true });
+    await server.initialize();
+    await server.start();
+  });
+
+  afterEach(async () => {
+    await server.stop();
+  });
+
+  describe('ListTools Integration', () => {
+    it('should include get_cached_value in ListTools response', async () => {
+      const response = await server['handleRequest']({
+        method: 'tools/list',
+        params: {},
+      });
+      const tools = response.tools as MCPTool[];
+      const tool = tools.find(t => t.name === 'iac_mcp_get_cached_value');
+
+      expect(tool).toBeDefined();
+      expect(tool!.description).toContain('cached large property value');
+      expect(tool!.inputSchema.required).toContain('ref');
+    });
+
+    it('should have tail_lines/head_lines in get_cached_value schema', async () => {
+      const response = await server['handleRequest']({
+        method: 'tools/list',
+        params: {},
+      });
+      const tools = response.tools as MCPTool[];
+      const tool = tools.find(t => t.name === 'iac_mcp_get_cached_value');
+
+      const props = tool!.inputSchema.properties as Record<string, any>;
+      expect(props.ref).toBeDefined();
+      expect(props.tail_lines).toBeDefined();
+      expect(props.head_lines).toBeDefined();
+      expect(props.offset_lines).toBeDefined();
+      expect(props.max_lines).toBeDefined();
+    });
+
+    it('should have tail_lines/head_lines in get_properties schema', async () => {
+      const response = await server['handleRequest']({
+        method: 'tools/list',
+        params: {},
+      });
+      const tools = response.tools as MCPTool[];
+      const tool = tools.find(t => t.name === 'iac_mcp_get_properties');
+
+      const props = tool!.inputSchema.properties as Record<string, any>;
+      expect(props.tail_lines).toBeDefined();
+      expect(props.head_lines).toBeDefined();
+    });
+
+    it('should have tail_lines/head_lines in get_elements_with_properties schema', async () => {
+      const response = await server['handleRequest']({
+        method: 'tools/list',
+        params: {},
+      });
+      const tools = response.tools as MCPTool[];
+      const tool = tools.find(t => t.name === 'iac_mcp_get_elements_with_properties');
+
+      const props = tool!.inputSchema.properties as Record<string, any>;
+      expect(props.tail_lines).toBeDefined();
+      expect(props.head_lines).toBeDefined();
+    });
+
+    it('should have tail_lines/head_lines in get_properties_batch schema', async () => {
+      const response = await server['handleRequest']({
+        method: 'tools/list',
+        params: {},
+      });
+      const tools = response.tools as MCPTool[];
+      const tool = tools.find(t => t.name === 'iac_mcp_get_properties_batch');
+
+      const props = tool!.inputSchema.properties as Record<string, any>;
+      expect(props.tail_lines).toBeDefined();
+      expect(props.head_lines).toBeDefined();
+    });
+  });
+
+  describe('CallTool - get_cached_value', () => {
+    it('should return cache_miss error for non-existent ref', async () => {
+      const response = await server['handleRequest']({
+        method: 'tools/call',
+        params: {
+          name: 'iac_mcp_get_cached_value',
+          arguments: { ref: 'cache_nonexistent' },
+        },
+      }) as { content: Array<{ type: string; text: string }>; isError?: boolean };
+
+      expect(response.isError).toBe(true);
+      const body = JSON.parse(response.content[0]!.text);
+      expect(body.error).toBe('cache_miss');
+    });
+
+    it('should return error for invalid params (missing ref)', async () => {
+      const response = await server['handleRequest']({
+        method: 'tools/call',
+        params: {
+          name: 'iac_mcp_get_cached_value',
+          arguments: {},
+        },
+      }) as { content: Array<{ type: string; text: string }>; isError?: boolean };
+
+      expect(response.isError).toBe(true);
+      const body = JSON.parse(response.content[0]!.text);
+      expect(body.error).toBe('invalid_parameter');
+    });
+  });
+
+  describe('Mutual Exclusivity Validation', () => {
+    it('should reject both tail_lines and head_lines on get_properties', async () => {
+      const response = await server['handleRequest']({
+        method: 'tools/call',
+        params: {
+          name: 'iac_mcp_get_properties',
+          arguments: { reference: 'ref_dummy', tail_lines: 10, head_lines: 10 },
+        },
+      }) as { content: Array<{ type: string; text: string }>; isError?: boolean };
+
+      expect(response.isError).toBe(true);
+      const body = JSON.parse(response.content[0]!.text);
+      expect(body.message).toContain('Cannot specify both');
+    });
+
+    it('should reject both tail_lines and head_lines on get_cached_value', async () => {
+      const response = await server['handleRequest']({
+        method: 'tools/call',
+        params: {
+          name: 'iac_mcp_get_cached_value',
+          arguments: { ref: 'cache_123', tail_lines: 5, head_lines: 5 },
+        },
+      }) as { content: Array<{ type: string; text: string }>; isError?: boolean };
+
+      expect(response.isError).toBe(true);
+      const body = JSON.parse(response.content[0]!.text);
+      expect(body.message).toContain('Cannot specify both');
+    });
+
+    it('should reject both tail_lines and head_lines on get_properties_batch', async () => {
+      const response = await server['handleRequest']({
+        method: 'tools/call',
+        params: {
+          name: 'iac_mcp_get_properties_batch',
+          arguments: { references: [], tail_lines: 5, head_lines: 5 },
+        },
+      }) as { content: Array<{ type: string; text: string }>; isError?: boolean };
+
+      expect(response.isError).toBe(true);
+      const body = JSON.parse(response.content[0]!.text);
+      expect(body.message).toContain('Cannot specify both');
+    });
+
+    it('should reject both tail_lines and head_lines on get_elements_with_properties', async () => {
+      const response = await server['handleRequest']({
+        method: 'tools/call',
+        params: {
+          name: 'iac_mcp_get_elements_with_properties',
+          arguments: {
+            container: { type: 'element', element: 'window', index: 0, container: 'application' },
+            elementType: 'tab',
+            properties: ['name'],
+            app: 'Safari',
+            tail_lines: 5,
+            head_lines: 5,
+          },
+        },
+      }) as { content: Array<{ type: string; text: string }>; isError?: boolean };
+
+      expect(response.isError).toBe(true);
+      const body = JSON.parse(response.content[0]!.text);
+      expect(body.message).toContain('Cannot specify both');
+    });
+  });
+});

--- a/tests/unit/execution/large-value-cache.test.ts
+++ b/tests/unit/execution/large-value-cache.test.ts
@@ -1,0 +1,237 @@
+/**
+ * Unit Tests for LargeValueCache
+ *
+ * Tests store/get/delete, TTL expiry, LRU eviction, and stats.
+ */
+
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import {
+  LargeValueCache,
+  LARGE_VALUE_THRESHOLD,
+  DEFAULT_MAX_CACHED_VALUES,
+  DEFAULT_TTL_MS,
+  PREVIEW_LINES,
+} from "../../../src/execution/large-value-cache.js";
+
+describe("LargeValueCache", () => {
+  let cache: LargeValueCache;
+
+  beforeEach(() => {
+    cache = new LargeValueCache();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("Constants", () => {
+    it("should export correct threshold value (50KB)", () => {
+      expect(LARGE_VALUE_THRESHOLD).toBe(50 * 1024);
+    });
+
+    it("should export correct default max entries", () => {
+      expect(DEFAULT_MAX_CACHED_VALUES).toBe(100);
+    });
+
+    it("should export correct default TTL (15 minutes)", () => {
+      expect(DEFAULT_TTL_MS).toBe(15 * 60 * 1000);
+    });
+
+    it("should export correct preview lines count", () => {
+      expect(PREVIEW_LINES).toBe(50);
+    });
+  });
+
+  describe("store()", () => {
+    it("should return a cache ID with cache_ prefix", () => {
+      const id = cache.store("hello", "text", "ref_abc");
+      expect(id).toMatch(/^cache_/);
+    });
+
+    it("should return unique IDs for different values", () => {
+      const id1 = cache.store("value1", "text", "ref_abc");
+      const id2 = cache.store("value2", "text", "ref_abc");
+      expect(id1).not.toBe(id2);
+    });
+
+    it("should store metadata correctly", () => {
+      const value = "line1\nline2\nline3";
+      const id = cache.store(value, "content", "ref_xyz");
+      const entry = cache.get(id);
+      expect(entry).toBeDefined();
+      expect(entry!.value).toBe(value);
+      expect(entry!.propertyName).toBe("content");
+      expect(entry!.sourceRef).toBe("ref_xyz");
+      expect(entry!.totalLines).toBe(3);
+      expect(entry!.totalChars).toBe(value.length);
+      expect(entry!.cachedAt).toBeGreaterThan(0);
+      expect(entry!.lastAccessedAt).toBeGreaterThan(0);
+    });
+
+    it("should count lines correctly for single-line value", () => {
+      const id = cache.store("no newlines here", "text", "ref_1");
+      const entry = cache.get(id);
+      expect(entry!.totalLines).toBe(1);
+    });
+
+    it("should count lines correctly for value ending with newline", () => {
+      const id = cache.store("line1\nline2\n", "text", "ref_1");
+      const entry = cache.get(id);
+      expect(entry!.totalLines).toBe(3); // split('\n') on "a\nb\n" = ["a","b",""]
+    });
+  });
+
+  describe("get()", () => {
+    it("should return undefined for non-existent ID", () => {
+      expect(cache.get("cache_nonexistent")).toBeUndefined();
+    });
+
+    it("should return the cached value", () => {
+      const id = cache.store("test value", "prop", "ref_1");
+      const entry = cache.get(id);
+      expect(entry).toBeDefined();
+      expect(entry!.value).toBe("test value");
+    });
+
+    it("should update lastAccessedAt on get", () => {
+      const id = cache.store("value", "prop", "ref_1");
+      const entry1 = cache.get(id);
+      const firstAccess = entry1!.lastAccessedAt;
+
+      // Advance time slightly
+      vi.spyOn(Date, "now").mockReturnValue(firstAccess + 1000);
+      const entry2 = cache.get(id);
+      expect(entry2!.lastAccessedAt).toBe(firstAccess + 1000);
+
+      vi.restoreAllMocks();
+    });
+
+    it("should return undefined for expired entries", () => {
+      const id = cache.store("value", "prop", "ref_1");
+      const entry = cache.get(id);
+      const cachedAt = entry!.cachedAt;
+
+      // Advance time past TTL
+      vi.spyOn(Date, "now").mockReturnValue(cachedAt + DEFAULT_TTL_MS + 1);
+      expect(cache.get(id)).toBeUndefined();
+
+      vi.restoreAllMocks();
+    });
+
+    it("should delete expired entries on access", () => {
+      const id = cache.store("value", "prop", "ref_1");
+      const entry = cache.get(id);
+      const cachedAt = entry!.cachedAt;
+
+      vi.spyOn(Date, "now").mockReturnValue(cachedAt + DEFAULT_TTL_MS + 1);
+      cache.get(id); // triggers deletion
+
+      vi.restoreAllMocks();
+
+      // Even with time restored, entry should be gone (was deleted)
+      expect(cache.getStats().totalEntries).toBe(0);
+    });
+  });
+
+  describe("delete()", () => {
+    it("should return true when entry exists", () => {
+      const id = cache.store("value", "prop", "ref_1");
+      expect(cache.delete(id)).toBe(true);
+    });
+
+    it("should return false when entry does not exist", () => {
+      expect(cache.delete("cache_nonexistent")).toBe(false);
+    });
+
+    it("should remove entry from cache", () => {
+      const id = cache.store("value", "prop", "ref_1");
+      cache.delete(id);
+      expect(cache.get(id)).toBeUndefined();
+    });
+  });
+
+  describe("clear()", () => {
+    it("should remove all entries", () => {
+      cache.store("v1", "p1", "ref_1");
+      cache.store("v2", "p2", "ref_2");
+      cache.store("v3", "p3", "ref_3");
+
+      cache.clear();
+      expect(cache.getStats().totalEntries).toBe(0);
+    });
+  });
+
+  describe("getStats()", () => {
+    it("should return zero for empty cache", () => {
+      const stats = cache.getStats();
+      expect(stats.totalEntries).toBe(0);
+      expect(stats.totalBytes).toBe(0);
+    });
+
+    it("should count entries and bytes", () => {
+      cache.store("hello", "p1", "ref_1"); // 5 chars
+      cache.store("world!!", "p2", "ref_2"); // 7 chars
+
+      const stats = cache.getStats();
+      expect(stats.totalEntries).toBe(2);
+      expect(stats.totalBytes).toBe(12);
+    });
+  });
+
+  describe("LRU Eviction", () => {
+    it("should evict the least recently used entry when at capacity", () => {
+      const smallCache = new LargeValueCache({ maxEntries: 3 });
+
+      const id1 = smallCache.store("first", "p", "ref_1");
+      const id2 = smallCache.store("second", "p", "ref_2");
+      const id3 = smallCache.store("third", "p", "ref_3");
+
+      // All three should exist
+      expect(smallCache.get(id1)).toBeDefined();
+      expect(smallCache.get(id2)).toBeDefined();
+      expect(smallCache.get(id3)).toBeDefined();
+
+      // Adding a 4th should evict the LRU one
+      // id1 was accessed first, so it's LRU after the gets above...
+      // Actually, we just accessed all three via get(). Let's use a fresh approach:
+      const freshCache = new LargeValueCache({ maxEntries: 3 });
+      const fid1 = freshCache.store("first", "p", "ref_1");
+      const fid2 = freshCache.store("second", "p", "ref_2");
+      const fid3 = freshCache.store("third", "p", "ref_3");
+
+      // Touch fid2 and fid3 to make fid1 the LRU
+      vi.spyOn(Date, "now").mockReturnValue(Date.now() + 1000);
+      freshCache.get(fid2);
+      freshCache.get(fid3);
+
+      vi.restoreAllMocks();
+
+      // Adding a 4th entry should evict fid1 (the LRU)
+      const fid4 = freshCache.store("fourth", "p", "ref_4");
+
+      expect(freshCache.get(fid1)).toBeUndefined(); // evicted
+      expect(freshCache.get(fid2)).toBeDefined();
+      expect(freshCache.get(fid3)).toBeDefined();
+      expect(freshCache.get(fid4)).toBeDefined();
+    });
+  });
+
+  describe("Custom TTL", () => {
+    it("should respect custom TTL", () => {
+      const shortTtlCache = new LargeValueCache({ ttlMs: 1000 }); // 1 second
+      const id = shortTtlCache.store("value", "p", "ref_1");
+      const entry = shortTtlCache.get(id);
+      const cachedAt = entry!.cachedAt;
+
+      // Should be available before TTL
+      vi.spyOn(Date, "now").mockReturnValue(cachedAt + 500);
+      expect(shortTtlCache.get(id)).toBeDefined();
+
+      // Should expire after TTL
+      vi.spyOn(Date, "now").mockReturnValue(cachedAt + 1001);
+      expect(shortTtlCache.get(id)).toBeUndefined();
+
+      vi.restoreAllMocks();
+    });
+  });
+});

--- a/tests/unit/execution/large-value-handling.test.ts
+++ b/tests/unit/execution/large-value-handling.test.ts
@@ -1,0 +1,318 @@
+/**
+ * Unit Tests for QueryExecutor Large Value Handling
+ *
+ * Tests processLargeValues, getCachedValue, and JXA line truncation.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { QueryExecutor } from "../../../src/execution/query-executor.js";
+import { ReferenceStore } from "../../../src/execution/reference-store.js";
+import { LargeValueCache, LARGE_VALUE_THRESHOLD, PREVIEW_LINES } from "../../../src/execution/large-value-cache.js";
+
+/**
+ * Helper: create a mock JXA result object matching ResultParser's expected format
+ */
+function jxaResult(data: unknown): { exitCode: number; stdout: string; stderr: string } {
+  return { exitCode: 0, stdout: JSON.stringify(data), stderr: "" };
+}
+
+describe("QueryExecutor Large Value Handling", () => {
+  let store: ReferenceStore;
+  let cache: LargeValueCache;
+  let executor: QueryExecutor;
+  let executeFn: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    store = new ReferenceStore();
+    cache = new LargeValueCache();
+
+    executeFn = vi.fn();
+    const mockJxaExecutor = { execute: executeFn } as any;
+
+    executor = new QueryExecutor(store, mockJxaExecutor, cache);
+  });
+
+  /**
+   * Helper: create a string of N lines, each ~80 chars
+   */
+  function makeLines(n: number): string {
+    return Array.from({ length: n }, (_, i) => `Line ${i + 1}: ${"x".repeat(70)}`).join("\n");
+  }
+
+  /**
+   * Helper: create a string larger than LARGE_VALUE_THRESHOLD
+   */
+  function makeLargeString(): string {
+    // Each line is ~80 chars + newline, so ~80 bytes per line
+    // 50KB / 80 ≈ 640 lines; let's use 700 to be safe
+    return makeLines(700);
+  }
+
+  describe("processLargeValues (via getProperties)", () => {
+    it("should pass through values below threshold unchanged", async () => {
+      const refId = store.create("TestApp", "window", {
+        type: "element",
+        element: "window",
+        index: 0,
+        container: "application",
+      });
+
+      const smallValue = "small text value";
+      executeFn.mockResolvedValue(jxaResult({ text: smallValue }));
+
+      const result = await executor.getProperties(refId, ["text"]);
+      expect(result.text).toBe(smallValue);
+    });
+
+    it("should auto-cache values exceeding threshold", async () => {
+      const refId = store.create("TestApp", "window", {
+        type: "element",
+        element: "window",
+        index: 0,
+        container: "application",
+      });
+
+      const largeValue = makeLargeString();
+      expect(largeValue.length).toBeGreaterThan(LARGE_VALUE_THRESHOLD);
+
+      executeFn.mockResolvedValue(jxaResult({ text: largeValue }));
+
+      const result = await executor.getProperties(refId, ["text"]);
+
+      // Should return a _large_value marker
+      expect(result.text._large_value).toBe(true);
+      expect(result.text._cached_ref).toMatch(/^cache_/);
+      expect(result.text._total_lines).toBe(largeValue.split("\n").length);
+      expect(result.text._total_chars).toBe(largeValue.length);
+      expect(typeof result.text._preview).toBe("string");
+    });
+
+    it("should include last N lines as preview", async () => {
+      const refId = store.create("TestApp", "window", {
+        type: "element",
+        element: "window",
+        index: 0,
+        container: "application",
+      });
+
+      const largeValue = makeLargeString();
+      executeFn.mockResolvedValue(jxaResult({ text: largeValue }));
+
+      const result = await executor.getProperties(refId, ["text"]);
+      const lines = largeValue.split("\n");
+      const expectedPreview = lines.slice(-PREVIEW_LINES).join("\n");
+      expect(result.text._preview).toBe(expectedPreview);
+    });
+
+    it("should not auto-cache when largeValueCache is not provided", async () => {
+      const noCacheExecutor = new QueryExecutor(store, { execute: executeFn } as any);
+      const refId = store.create("TestApp", "window", {
+        type: "element",
+        element: "window",
+        index: 0,
+        container: "application",
+      });
+
+      const largeValue = makeLargeString();
+      executeFn.mockResolvedValue(jxaResult({ text: largeValue }));
+
+      const result = await noCacheExecutor.getProperties(refId, ["text"]);
+      // Should return raw value (no _large_value marker)
+      expect(result.text).toBe(largeValue);
+    });
+
+    it("should only cache string values, not objects", async () => {
+      const refId = store.create("TestApp", "window", {
+        type: "element",
+        element: "window",
+        index: 0,
+        container: "application",
+      });
+
+      executeFn.mockResolvedValue(jxaResult({ name: "hello", count: 42, visible: true }));
+
+      const result = await executor.getProperties(refId, ["name", "count", "visible"]);
+      expect(result.name).toBe("hello");
+      expect(result.count).toBe(42);
+      expect(result.visible).toBe(true);
+    });
+  });
+
+  describe("getCachedValue", () => {
+    it("should return full value when no options specified", () => {
+      const value = "line1\nline2\nline3\nline4\nline5";
+      const cacheId = cache.store(value, "text", "ref_1");
+
+      const result = executor.getCachedValue(cacheId);
+      expect(result.value).toBe(value);
+      expect(result.total_lines).toBe(5);
+      expect(result.total_chars).toBe(value.length);
+      expect(result.lines_returned).toBe(5);
+    });
+
+    it("should return last N lines with tail_lines", () => {
+      const value = "line1\nline2\nline3\nline4\nline5";
+      const cacheId = cache.store(value, "text", "ref_1");
+
+      const result = executor.getCachedValue(cacheId, { tail_lines: 2 });
+      expect(result.value).toBe("line4\nline5");
+      expect(result.lines_returned).toBe(2);
+    });
+
+    it("should return first N lines with head_lines", () => {
+      const value = "line1\nline2\nline3\nline4\nline5";
+      const cacheId = cache.store(value, "text", "ref_1");
+
+      const result = executor.getCachedValue(cacheId, { head_lines: 3 });
+      expect(result.value).toBe("line1\nline2\nline3");
+      expect(result.lines_returned).toBe(3);
+    });
+
+    it("should apply offset_lines before tail_lines", () => {
+      const value = "line1\nline2\nline3\nline4\nline5";
+      const cacheId = cache.store(value, "text", "ref_1");
+
+      const result = executor.getCachedValue(cacheId, { offset_lines: 1, tail_lines: 2 });
+      // After offset: line2, line3, line4, line5
+      // After tail(2): line4, line5
+      expect(result.value).toBe("line4\nline5");
+      expect(result.lines_returned).toBe(2);
+    });
+
+    it("should apply offset_lines before head_lines", () => {
+      const value = "line1\nline2\nline3\nline4\nline5";
+      const cacheId = cache.store(value, "text", "ref_1");
+
+      const result = executor.getCachedValue(cacheId, { offset_lines: 2, head_lines: 2 });
+      // After offset: line3, line4, line5
+      // After head(2): line3, line4
+      expect(result.value).toBe("line3\nline4");
+      expect(result.lines_returned).toBe(2);
+    });
+
+    it("should apply max_lines cap", () => {
+      const value = "line1\nline2\nline3\nline4\nline5";
+      const cacheId = cache.store(value, "text", "ref_1");
+
+      const result = executor.getCachedValue(cacheId, { max_lines: 3 });
+      expect(result.value).toBe("line1\nline2\nline3");
+      expect(result.lines_returned).toBe(3);
+    });
+
+    it("should throw for non-existent cache ref", () => {
+      expect(() => executor.getCachedValue("cache_nonexistent")).toThrow(
+        /Cached value not found/
+      );
+    });
+
+    it("should throw when largeValueCache is not available", () => {
+      const noCacheExecutor = new QueryExecutor(store, { execute: executeFn } as any);
+      expect(() => noCacheExecutor.getCachedValue("cache_123")).toThrow(
+        /Large value cache is not available/
+      );
+    });
+
+    it("should include slice description in response", () => {
+      const cacheId = cache.store("a\nb\nc", "text", "ref_1");
+
+      const r1 = executor.getCachedValue(cacheId);
+      expect(r1.slice).toBe("full");
+
+      const r2 = executor.getCachedValue(cacheId, { tail_lines: 2 });
+      expect(r2.slice).toContain("tail 2");
+
+      const r3 = executor.getCachedValue(cacheId, { head_lines: 1, offset_lines: 1 });
+      expect(r3.slice).toContain("offset 1");
+      expect(r3.slice).toContain("head 1");
+    });
+  });
+
+  describe("JXA Line Truncation (buildPropertyAccessorIIFE)", () => {
+    it("should include tail_lines truncation in JXA code", async () => {
+      const refId = store.create("TestApp", "session", {
+        type: "element",
+        element: "session",
+        index: 0,
+        container: "application",
+      });
+
+      executeFn.mockResolvedValue(jxaResult({ text: "last line" }));
+
+      await executor.getProperties(refId, ["text"], { tail_lines: 50 });
+
+      const jxaCode = executeFn.mock.calls[0]![0] as string;
+      expect(jxaCode).toContain("slice(-50)");
+    });
+
+    it("should include head_lines truncation in JXA code", async () => {
+      const refId = store.create("TestApp", "session", {
+        type: "element",
+        element: "session",
+        index: 0,
+        container: "application",
+      });
+
+      executeFn.mockResolvedValue(jxaResult({ text: "first line" }));
+
+      await executor.getProperties(refId, ["text"], { head_lines: 10 });
+
+      const jxaCode = executeFn.mock.calls[0]![0] as string;
+      expect(jxaCode).toContain("slice(0, 10)");
+    });
+
+    it("should not include truncation code when no options", async () => {
+      const refId = store.create("TestApp", "session", {
+        type: "element",
+        element: "session",
+        index: 0,
+        container: "application",
+      });
+
+      executeFn.mockResolvedValue(jxaResult({ text: "value" }));
+
+      await executor.getProperties(refId, ["text"]);
+
+      const jxaCode = executeFn.mock.calls[0]![0] as string;
+      // Should not contain line splitting/slicing for truncation
+      expect(jxaCode).not.toContain("lines.slice");
+    });
+
+    it("should pass options through getPropertiesBatch", async () => {
+      const refId = store.create("TestApp", "session", {
+        type: "element",
+        element: "session",
+        index: 0,
+        container: "application",
+      });
+
+      executeFn.mockResolvedValue(
+        jxaResult([{ idx: 0, props: { text: "value" } }])
+      );
+
+      await executor.getPropertiesBatch([refId], ["text"], { tail_lines: 25 });
+
+      const jxaCode = executeFn.mock.calls[0]![0] as string;
+      expect(jxaCode).toContain("slice(-25)");
+    });
+
+    it("should pass options through getElementsWithProperties", async () => {
+      const refId = store.create("TestApp", "window", {
+        type: "element",
+        element: "window",
+        index: 0,
+        container: "application",
+      });
+
+      executeFn.mockResolvedValue(
+        jxaResult({ count: 1, items: [{ index: 0, props: { text: "value" } }] })
+      );
+
+      await executor.getElementsWithProperties(
+        refId, "tab", ["text"], undefined, 100, { head_lines: 30 }
+      );
+
+      const jxaCode = executeFn.mock.calls[0]![0] as string;
+      expect(jxaCode).toContain("slice(0, 30)");
+    });
+  });
+});

--- a/tests/unit/jitd/tool-generator/query-tools.test.ts
+++ b/tests/unit/jitd/tool-generator/query-tools.test.ts
@@ -3,11 +3,11 @@ import { generateQueryTools } from "../../../../src/jitd/tool-generator/query-to
 import { Tool } from "@modelcontextprotocol/sdk/types.js";
 
 describe("generateQueryTools", () => {
-  describe("Function Returns 6 Tools", () => {
-    it("should return an array of 6 tools", () => {
+  describe("Function Returns 7 Tools", () => {
+    it("should return an array of 7 tools", () => {
       const tools = generateQueryTools();
       expect(tools).toBeInstanceOf(Array);
-      expect(tools).toHaveLength(6);
+      expect(tools).toHaveLength(7);
     });
 
     it("should return tools with name, description, and inputSchema", () => {


### PR DESCRIPTION
## Summary
- New `LargeValueCache` class with LRU eviction (100 entries) and 15-min TTL for auto-caching oversized property values
- `tail_lines`/`head_lines` parameters on `get_properties`, `get_properties_batch`, and `get_elements_with_properties` for JXA-side line truncation before values cross the osascript bridge
- Auto-cache safety net: string values >50KB are cached server-side, response contains preview (last 50 lines) + `_cached_ref` for paging
- New `iac_mcp_get_cached_value` tool with `offset_lines`, `head_lines`, `tail_lines`, `max_lines` for paging through cached large values
- Mutual exclusivity validation: `tail_lines` and `head_lines` cannot both be specified

## Test plan
- [x] 22 unit tests for LargeValueCache (store/get/delete, TTL, LRU eviction, stats)
- [x] 19 unit tests for QueryExecutor large value behavior (threshold, auto-cache, preview, JXA truncation code generation)
- [x] 11 integration tests for MCP server (tool schemas, routing, mutual exclusivity validation)
- [x] Updated existing query-tools test for new tool count (6 → 7)
- [x] Full test suite passes (2953 tests, only pre-existing sdef-validation failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)